### PR TITLE
Adding check for errors while signing-in

### DIFF
--- a/pages/signin.js
+++ b/pages/signin.js
@@ -1,17 +1,47 @@
 import React from "react";
 import { providers, signIn, getSession } from "next-auth/client";
+import { useRouter } from "next/dist/client/router";
+
+const SignInError = ({ error }) => {
+  const errors = {
+      Signin: 'Try signing in with a different account.',
+      OAuthSignin: 'Try signing in with a different account.',
+      OAuthCallback: 'Try signing in with a different account.',
+      OAuthCreateAccount: 'Try signing in with a different account.',
+      EmailCreateAccount: 'Try signing in with a different account.',
+      Callback: 'Try signing in with a different account.',
+      OAuthAccountNotLinked: 'Please sign in with the same account you used orignally.',
+      EmailSignin: 'Check your email address.',
+      CredentialsSignin: 'Sign in failed. Make sure the details you provided are correct.',
+      default: 'Unable to sign in.'
+  }
+
+  const errorMessage = error && (errors[error] ?? errors.default)
+
+  return <div className="signin-error">{errorMessage}</div>
+}
+
 export default function SignIn({ providers }) {
+  const {
+    query: {callbackUrl, error},
+  } = useRouter()
+
   return (
     <div>
+      {error &&
+        <SignInError error={error} />
+      }
       {Object.values(providers).map((provider) => {
         if (provider.name === "Email") {
             return;
         }
       return (
-        <div key={provider.name}>
-          <button variant="outline" onClick={() => signIn(provider.id)}>
-            Sign in with {provider.name}
-          </button>
+        <div>
+          <div key={provider.name}>
+            <button variant="outline" onClick={() => signIn(provider.id)}>
+              Sign in with {provider.name}
+            </button>
+          </div>
         </div>
       );
       })}


### PR DESCRIPTION
Adding a check when the user has already created an account with an email and tries to use that email for another third-party auth along with other error checks.

If an error occurs, the user is redirected to the sign-in page with an error message telling them a message related to the error they received.